### PR TITLE
Make sure we use obj files for effeciency in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,15 +12,17 @@ obj = $(src:.c=.o)
 
 CFLAGS = -std=c11 -Wall
 
+all: $(BIN) hello_world ch3_bonus_marks
+
 $(BIN): $(obj)
 	$(CC) $(CFLAGS) -o $@ $^
 
-hello_world: $(hello_world_src)
+hello_world: $(hello_world_obj)
 	$(CC) -o $@ $^
 
-ch3_bonus_marks: $(ch3_bonus_marks_src)
+ch3_bonus_marks: $(ch3_bonus_marks_obj)
 	$(CC) -o $@ $^
 
 .PHONY: clean
 clean:
-	rm -v $(obj) $(BIN) hello_world ch3_bonus_marks
+	rm -v $(obj) $(BIN) $(hello_world_obj) hello_world $(ch3_bonus_marks_obj) ch3_bonus_marks


### PR DESCRIPTION
So that Make doesn't recompile absolutely everything whenever a single
src file is updated. Kinda like a compile cache.

Also, this adds an 'all' recipe as the default target, which does pretty
much what it says on the tin.