### PR TITLE
Add dummy functions for Windows compatibility.

### DIFF
--- a/main.c
+++ b/main.c
@@ -8,8 +8,31 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+// Windows doesn't need the editline library, so we'll use some trick,
+// compatibility functions instead.
+#ifdef _WIN32
+#include <string.h>
+
+#define _WIN_INPUT_BUF_SIZE 2048
+static char buffer[_WIN_INPUT_BUF_SIZE];
+
+/** Fake readline function. */
+char* readline(char* prompt) {
+	fputs(prompt, stdout);
+	fgets(buffer, _WIN_INPUT_BUF_SIZE, stdin);
+	char* cpy = malloc(strlen(buffer) + 1);
+	strcpy(cpy, buffer);
+	cpy[strlen(cpy) - 1] = '\0';
+	return cpy;
+}
+
+/** Fake add_history function */
+void add_history(char* unused) {}
+
+#else
 #include <editline/readline.h>
 #include <editline/history.h>
+#endif // _WIN32
 
 int main(int argc, char** argv) {
 	// Print version & exit info


### PR DESCRIPTION
Windows apparently doesn't need/ have the editline library. Who knew. So now we wrap calls to fputs, fgets, etc. in a dummy readline function for functionality. I didn't bother implementing history, so the add_history dummy function is just a no-op.

Fixes #6.