### PR TITLE
Ch6 polish notation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-# C object files
-*.o
+# Build directory
+build
 
 # Binaries
 lispy

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "mpc"]
+	path = mpc
+	url = https://github.com/orangeduck/mpc

--- a/Makefile
+++ b/Makefile
@@ -1,29 +1,56 @@
 BIN = lispy
+BUILD_DIR = build
 
 hello_world_src = hello_world.c
-hello_world_obj = $(hello_world_src:.c=.o)
+hello_world_obj = $(hello_world_src:%.c=$(BUILD_DIR)/%.o)
 
 ch3_bonus_marks_src = ch3_bonus_marks.c
-ch3_bonus_marks_obj = $(ch3_bonus_marks_src:.c=.o)
+ch3_bonus_marks_obj = $(ch3_bonus_marks_src:%.c=$(BUILD_DIR)/%.o)
 
 _ignored_sources = $(hello_world_src) $(ch3_bonus_marks_src)
-src = $(filter-out $(_ignored_sources), $(wildcard *.c))
-obj = $(src:.c=.o)
+src = $(filter-out $(_ignored_sources), $(wildcard *.c)) mpc/mpc.c
+obj = $(src:%.c=$(BUILD_DIR)/%.o)
+dep = $(obj:.o=.d) # one dependency file for each source, for dependency tracking.
 
 CFLAGS = -std=c11 -Wall
-LDFLAGS = -ledit
+LDFLAGS = -ledit -lm
 
 all: $(BIN) hello_world ch3_bonus_marks
+
+$(obj): $(BUILD_DIR)/%.o: %.c
+	@mkdir -p $(BUILD_DIR) $(BUILD_DIR)/mpc
+	$(CC) $(CFLAGS) -o $@ -c $<
 
 $(BIN): $(obj)
 	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
 
+$(hello_world_obj): $(BUILD_DIR)/%.o: %.c
+	@mkdir -p $(BUILD_DIR) $(BUILD_DIR)/mpc
+	$(CC) $(CFLAGS) -o $@ -c $<
+
 hello_world: $(hello_world_obj)
 	$(CC) -o $@ $^
+
+$(ch3_bonus_marks_obj): $(BUILD_DIR)/%.o: %.c
+	@mkdir -p $(BUILD_DIR) $(BUILD_DIR)/mpc
+	$(CC) $(CFLAGS) -o $@ -c $<
 
 ch3_bonus_marks: $(ch3_bonus_marks_obj)
 	$(CC) -o $@ $^
 
+# Include all dep files in the Makefile
+-include $(dep)
+
+# Rule to generate a dep file by using the C preprocessor
+# (see `man cpp` for details on the -MM and -MT options).
+$(BUILD_DIR)/%.d: %.c
+	@mkdir -p $(BUILD_DIR) $(BUILD_DIR)/mpc
+	@$(CPP) $(CFLAGS) $< -MM -MT $(@:.d=.o) >$@
+
 .PHONY: clean
 clean:
-	rm -v $(obj) $(BIN) $(hello_world_obj) hello_world $(ch3_bonus_marks_obj) ch3_bonus_marks
+	rm -rv $(BUILD_DIR) $(BIN) hello_world ch3_bonus_marks
+
+.PHONY: cleandep
+cleandep:
+	rm -v $(dep)

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ one or more *expressions*.
 
 More formally:
 
-| Symbol         | Definition                                                                              |
-|----------------|-----------------------------------------------------------------------------------------|
-| `<program>`    | The start of input, an `<operator>`, one or more `<expression>`s, and the end of input. |
-| `<expression>` | Either a `<number>` or a `(`, an `<operator>`, one or more `<expression>`s, and a `)`.  |
-| `<operator>`   | `+`/`add`, `-`/`sub`, `*`/`mul`, `/`/`div`, or `%`/`mod`.                               |
-| `<number>`     | An optional `-`, and one or more characters between 0 and 9 (inclusive).                |
+| Symbol         | Definition                                                                                                 |
+|----------------|------------------------------------------------------------------------------------------------------------|
+| `<program>`    | The start of input, an `<operator>`, one or more `<expression>`s, and the end of input.                    |
+| `<expression>` | Either a `<number>` or a `(`, an `<operator>`, one or more `<expression>`s, and a `)`.                     |
+| `<operator>`   | `+`/`add`, `-`/`sub`, `*`/`mul`, `/`/`div`, or `%`/`mod`.                                                  |
+| `<number>`     | An optional `-`, one or more digits from 0 thru 9, an optional `.`, and zero or more digits from 0 thru 9. |

--- a/README.md
+++ b/README.md
@@ -49,5 +49,5 @@ More formally:
 |----------------|-----------------------------------------------------------------------------------------|
 | `<program>`    | The start of input, an `<operator>`, one or more `<expression>`s, and the end of input. |
 | `<expression>` | Either a `<number>` or a `(`, an `<operator>`, one or more `<expression>`s, and a `)`.  |
-| `<operator>`   | `+`, `-`, `*`, or `/`.                                                                  |
+| `<operator>`   | `+`/`add`, `-`/`sub`, `*`/`mul`, `/`/`div`, or `%`/`mod`.                               |
 | `<number>`     | An optional `-`, and one or more characters between 0 and 9 (inclusive).                |

--- a/README.md
+++ b/README.md
@@ -9,6 +9,19 @@ really necessary, but I'm treating it as an exercise in programming
 cleanliness. I might add things, remove things... Let's see what I can do :grin:
 
 ## Building
+This project uses [git submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules).
+Make sure to run the following commands after cloning:
+
+```bash
+$ git submodule init
+$ git submodule update
+```
+
+Or, just use the `--recurse-submodules` option when cloning this repo, i.e:
+
+```bash
+$ git clone --recurse-submodules https://github.com/jo12bar/build-your-own-lisp-c.git
+```
 
 ### Requirements
 - GNU `make`, `gcc` (or just `cc`&mdash;basically the same thing), etc... If

--- a/README.md
+++ b/README.md
@@ -18,3 +18,23 @@ cleanliness. I might add things, remove things... Let's see what I can do :grin:
   - __*Mac*__: Should be installed with the *Command Line Tools*.
   - __*Debian, Ubuntu, etc*__: `sudo apt install libedit-dev`
   - __*Fedora, etc*__: `su -c "yum install libedit-dev*"`
+
+## Language Spec
+
+Currently just an implementation of
+[polish notation](http://en.wikipedia.org/wiki/Polish_notation), but this
+should make it trivial to implement the rest of Lispy as all Lisps use
+polish-notation-like grammar.
+
+A *program* is an *operator* followed by one or more *expressions*, where an
+*expression* is either a *number*, or, in parentheses, an *operator* followed by
+one or more *expressions*.
+
+More formally:
+
+| Symbol         | Definition                                                                              |
+|----------------|-----------------------------------------------------------------------------------------|
+| `<program>`    | The start of input, an `<operator>`, one or more `<expression>`s, and the end of input. |
+| `<expression>` | Either a `<number>` or a `(`, an `<operator>`, one or more `<expression>`s, and a `)`.  |
+| `<operator>`   | `+`, `-`, `*`, or `/`.                                                                  |
+| `<number>`     | An optional `-`, and one or more characters between 0 and 9 (inclusive).                |

--- a/main.c
+++ b/main.c
@@ -59,9 +59,20 @@ int main(int argc, char** argv) {
 	while(1) {
 		// Output our prompt and get input.
 		char* input = readline("lispy> ");
-
 		add_history(input);
-		printf("No you're a %s\n", input);
+
+		// Attempt to parse the user input
+		mpc_result_t r;
+		if (mpc_parse("<stdin>", input, Lispy, &r)) {
+			// Print the AST on success.
+			mpc_ast_print(r.output);
+			mpc_ast_delete(r.output);
+		}
+		else {
+			mpc_err_print(r.error);
+			mpc_err_delete(r.error);
+		}
+
 		free(input);
 	}
 

--- a/main.c
+++ b/main.c
@@ -45,7 +45,7 @@ int main(int argc, char** argv) {
 
 	mpca_lang(MPCA_LANG_DEFAULT,
 		"                                                  \
-		number   : /-?[0-9]+/ ;                            \
+		number   : /-?[0-9]+\\.?[0-9]*/ ;                  \
 		operator : '+' | \"add\"                           \
 		         | '-' | \"sub\"                           \
 		         | '*' | \"mul\"                           \

--- a/main.c
+++ b/main.c
@@ -8,6 +8,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include "mpc/mpc.h"
+
 // Windows doesn't need the editline library, so we'll use some trick,
 // compatibility functions instead.
 #ifdef _WIN32
@@ -35,6 +37,21 @@ void add_history(char* unused) {}
 #endif // _WIN32
 
 int main(int argc, char** argv) {
+	// Create some parsers
+	mpc_parser_t* Number   = mpc_new("number");
+	mpc_parser_t* Operator = mpc_new("operator");
+	mpc_parser_t* Expr     = mpc_new("expr");
+	mpc_parser_t* Lispy    = mpc_new("lispy");
+
+	mpca_lang(MPCA_LANG_DEFAULT,
+		"                                                  \
+		number   : /-?[0-9]+/ ;                            \
+		operator : '+' | '-' | '*' | '/' ;                 \
+		expr     : <number> | '(' <operator> <expr>+ ')' ; \
+		lispy    : /^/ <operator> <expr>+ /$/ ;            \
+		",
+		Number, Operator, Expr, Lispy);
+
 	// Print version & exit info
 	puts("Lispy version 0.0.1");
 	puts("Press Ctrl+c to Exit\n");
@@ -47,6 +64,9 @@ int main(int argc, char** argv) {
 		printf("No you're a %s\n", input);
 		free(input);
 	}
+
+	// Undefine & delete our parsers.
+	mpc_cleanup(4, Number, Operator, Expr, Lispy);
 
 	return 0;
 }

--- a/main.c
+++ b/main.c
@@ -46,7 +46,11 @@ int main(int argc, char** argv) {
 	mpca_lang(MPCA_LANG_DEFAULT,
 		"                                                  \
 		number   : /-?[0-9]+/ ;                            \
-		operator : '+' | '-' | '*' | '/' ;                 \
+		operator : '+' | \"add\"                           \
+		         | '-' | \"sub\"                           \
+		         | '*' | \"mul\"                           \
+		         | '/' | \"div\"                           \
+		         | '%' | \"mod\" ;                         \
 		expr     : <number> | '(' <operator> <expr>+ ')' ; \
 		lispy    : /^/ <operator> <expr>+ /$/ ;            \
 		",


### PR DESCRIPTION
Implements parsing for [polish notation](http://en.wikipedia.org/wiki/Polish_notation), which can be seen as a subset of a Lisp. Specifically:
- We now use [`mpc`](https://github.com/orangeduck/mpc) for parsing (it's installed as a submodule, so watch out!)
- The build system has been revamped a bit so that all `.o` object files are placed in a `build/` directory.
  - This is mostly to make sure that we don't defile the `mpc` submodule whenever we build.
- We now generate `.d` dependency tracking files with the C Preprocessor so that changes in one file doesn't cause the *entire* project to be rebuilt
  - These are also stored in the `build/` directory
- The grammar is parsed from user input, and the AST is printed (or errors, if there are any).
- See the new README.md for the grammar spec.
- See the commits for more info on changed stuff :grin: